### PR TITLE
use self.stdenv.hostPlatform.system instead of self.system

### DIFF
--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -2,13 +2,17 @@
   nixpkgs,
   aikadm-frontend,
   ...
-}: {
-  default = final: _prev: let
-    packages = import ./pkgs.nix {
-      inherit nixpkgs aikadm-frontend;
-      system = final.system;
+}:
+{
+  default =
+    self: super:
+    let
+      packages = import ./pkgs.nix {
+        inherit nixpkgs aikadm-frontend;
+        system = self.stdenv.hostPlatform.system;
+      };
+    in
+    {
+      aikadm = packages;
     };
-  in {
-    aikadm = packages;
-  };
 }


### PR DESCRIPTION
Reason explained by grok3: [self.stdenv.hostPlatform.system可以直接用self.system代替吗？他们有什么不一样吗](https://grok.com/share/bGVnYWN5_42a0740d-7f0b-43dc-a11f-197fab3dad6a)(In the final conversation)